### PR TITLE
Upgrade SCI

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,7 @@
 {:paths ["src/main"]
 
  :deps {instaparse/instaparse    {:mvn/version "1.4.10"}
-        borkdude/edamame         {:mvn/version "0.0.11"}
-        borkdude/sci             {:mvn/version "0.2.5"}
+        org.babashka/sci         {:mvn/version "0.3.2"}
         meander/epsilon          {:mvn/version "0.0.602"}
         medley/medley            {:mvn/version "1.3.0"}
         net.cgrand/macrovich     {:mvn/version "0.2.1"}


### PR DESCRIPTION
SCI has moved to a new organization: `org.babashka/sci {:mvn/version "0.3.2"}`.

Having both `borkdude/sci` and `org.babashka/sci` on the classpath can cause problems.
It's also recommended to use the same edamame version that SCI uses to prevent incompatibilities, so using it as a transitive dependency is fine.